### PR TITLE
Directory restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,15 @@ Alias "/youtube" "/path/to/this/repository"
 
 This project requires `videos/` to be in a specific format. All files must be named by their YouTube ID, which guarantees unique and simple filenames. Metadata and thumbnails for each video are also needed.
 
+Furthermore, `videos/` must be partitioned by channel. These subdirectories must be named using the 24-character YouTube channel ID. The user is encouraged, but not required, to create symbolic links to these directories for easier reference.
+
 ```txt
 videos/
-├── dQw4w9WgXcQ.info.json
-├── dQw4w9WgXcQ.mp4
-└── dQw4w9WgXcQ.webp
+├── TheAngryGrandpaShow -> UCPFVhmjjSkFhfstm2LghZIg/
+└── UCPFVhmjjSkFhfstm2LghZIg
+    ├── zVQ61CpWBRk.info.json
+    ├── zVQ61CpWBRk.mp4
+    └── zVQ61CpWBRk.webp
 ```
 
 The following `youtube-dl` options are directly responsible for creating the output as described. See [remarks on `youtube-dl`](#remarks-on-youtube-dl) for more details.

--- a/channel.php
+++ b/channel.php
@@ -55,6 +55,7 @@ if (!($result && $channel = $result->fetch_object())) {
                 video.video_id AS id,
                 video.title AS title,
                 video.upload_date AS upload_date,
+                video.channel_id AS channel_id,
                 video.duration AS duration,
                 video.view_count AS view_count,
                 video.thumbnail AS thumbnail
@@ -75,7 +76,7 @@ if (!($result && $channel = $result->fetch_object())) {
             $thumbnail = $video->thumbnail;
             if (preg_match("/\.([[:alnum:]]+)(\?.*)?$/", $thumbnail, $matches)) {
                 $thumb_ext = $matches[1];
-                $thumbnail = "/videos/{$video->id}.{$thumb_ext}";
+                $thumbnail = "/videos/$video->channel_id/$video->id.$thumb_ext";
             } ?>
             <figure class="video-block">
                 <div class="video-thumbnail">

--- a/watch.php
+++ b/watch.php
@@ -8,6 +8,7 @@ $stmt = $mysqli->prepare(
         video.video_id AS id,
         video.title AS title,
         video.description AS description,
+        video.channel_id AS channel_id,
         video.ext AS ext
     FROM video
     WHERE
@@ -34,7 +35,7 @@ if (!($result && $video = $result->fetch_object())) {
 
 <body>
     <h1><?php echo htmlspecialchars($video->title); ?></h1>
-    <video controls src="/videos/<?php echo "{$video->id}.{$video->ext}"; ?>">
+    <video controls src="/videos/<?php echo "$video->channel_id/$video->id.$video->ext"; ?>">
         <em>Your browser does not support embedded videos</em>
     </video>
     <pre class="video-description"><?php echo htmlspecialchars($video->description); ?></pre>


### PR DESCRIPTION
Require `videos/` directory to be partitioned by channel. For example, `videos/zVQ61CpWBRk.mp4` becomes `videos/UCPFVhmjjSkFhfstm2LghZIg/zVQ61CpWBRk.mp4`.